### PR TITLE
perbaikan: inisialisasi variabel x dan y pada bagian kasus dua sampel…

### DIFF
--- a/statnonpar_kelompok3_komstat.R
+++ b/statnonpar_kelompok3_komstat.R
@@ -410,6 +410,8 @@ Kesimpulan: Tidak ada bukti perbedaan signifikan
   observeEvent(input$ok_indep, {
     df <- dataInputIndep()
     req(df)
+    x <- df[[1]]
+    y <- df[[2]]
     
     # ==== UJI CHI-SQUARE UNTUK NOMINAL, DUA SAMPEL INDEPENDEN ====
     if (input$jenis_data_indep == "Nominal" && input$uji_nominal_indep == "chisq") {


### PR DESCRIPTION
… independen

Sebelumnya, uji Kolmogorov–Smirnov dan uji ordinal lainnya pada tab "Dua Sampel Independen" gagal dijalankan karena variabel 'x' dan 'y' belum terdefinisi. Commit ini menambahkan inisialisasi x <- df[[1]] dan y <- df[[2]] setelah pembacaan data CSV, sehingga semua uji dapat mengakses data dengan benar.

Mempengaruhi:
- Uji Kolmogorov–Smirnov (KS)
- Uji Mann–Whitney U
- Uji Median
- Uji Wald–Wolfowitz

Memperbaiki: error 'object x not found'